### PR TITLE
[Feat/#1 layout] Header, NavBar 구현 및 기본 라우터 설정

### DIFF
--- a/sanjijikfarm/package.json
+++ b/sanjijikfarm/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query-devtools": "^5.85.9",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/sanjijikfarm/src/App.jsx
+++ b/sanjijikfarm/src/App.jsx
@@ -1,13 +1,7 @@
-import { Outlet } from 'react-router-dom';
+import Layout from './components/common/layout/Layout';
 
 function App() {
-  return (
-    <div className="h-screen w-full">
-      <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">
-        <Outlet />
-      </div>
-    </div>
-  );
+  return <Layout />;
 }
 
 export default App;

--- a/sanjijikfarm/src/App.jsx
+++ b/sanjijikfarm/src/App.jsx
@@ -1,7 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
 function App() {
   return (
     <div className="h-screen w-full">
-      <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">pages</div>
+      <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">
+        <Outlet />
+      </div>
     </div>
   );
 }

--- a/sanjijikfarm/src/App.jsx
+++ b/sanjijikfarm/src/App.jsx
@@ -1,7 +1,9 @@
-import Layout from './components/common/layout/Layout';
+import { RouterProvider } from 'react-router-dom';
 
-function App() {
-  return <Layout />;
-}
+import { router } from './router';
+
+const App = () => {
+  return <RouterProvider router={router} />;
+};
 
 export default App;

--- a/sanjijikfarm/src/components/common/layout/Header.jsx
+++ b/sanjijikfarm/src/components/common/layout/Header.jsx
@@ -1,7 +1,21 @@
+// src/components/common/layout/Header.jsx
+import { useLocation } from 'react-router-dom';
+
+const titles = {
+  '/home': '홈',
+  '/receipt': '영수증',
+  '/localfood': '로컬푸드',
+  '/report': '소비리포트',
+  '/mypage': '마이페이지',
+};
+
 export default function Header() {
+  const location = useLocation();
+  const title = titles[location.pathname] || '';
+
   return (
     <div className="absolute top-0 flex h-16 w-full items-center justify-center bg-white shadow-sm">
-      <span className="text-heading-1 font-bold">홈</span>
+      <span className="text-heading-1 font-bold">{title}</span>
     </div>
   );
 }

--- a/sanjijikfarm/src/components/common/layout/Header.jsx
+++ b/sanjijikfarm/src/components/common/layout/Header.jsx
@@ -1,6 +1,6 @@
 export default function Header() {
   return (
-    <div className="flex h-16 w-full items-center justify-center bg-white shadow-md">
+    <div className="absolute top-0 flex h-16 w-full items-center justify-center bg-white shadow-md">
       <span className="text-heading-1 font-bold">Path 인식, 헤더</span>
     </div>
   );

--- a/sanjijikfarm/src/components/common/layout/Header.jsx
+++ b/sanjijikfarm/src/components/common/layout/Header.jsx
@@ -1,0 +1,7 @@
+export default function Header() {
+  return (
+    <div className="flex h-16 w-full items-center justify-center bg-white shadow-md">
+      <span className="text-heading-1 font-bold">Path 인식, 헤더</span>
+    </div>
+  );
+}

--- a/sanjijikfarm/src/components/common/layout/Header.jsx
+++ b/sanjijikfarm/src/components/common/layout/Header.jsx
@@ -1,7 +1,7 @@
 export default function Header() {
   return (
-    <div className="absolute top-0 flex h-16 w-full items-center justify-center bg-white shadow-md">
-      <span className="text-heading-1 font-bold">Path 인식, 헤더</span>
+    <div className="absolute top-0 flex h-16 w-full items-center justify-center bg-white shadow-sm">
+      <span className="text-heading-1 font-bold">홈</span>
     </div>
   );
 }

--- a/sanjijikfarm/src/components/common/layout/Layout.jsx
+++ b/sanjijikfarm/src/components/common/layout/Layout.jsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
 import Header from './Header';
+import NavBar from './NavBar';
 
 export default function Layout() {
   return (
@@ -8,6 +9,7 @@ export default function Layout() {
       <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">
         <Header />
         <Outlet />
+        <NavBar />
       </div>
     </div>
   );

--- a/sanjijikfarm/src/components/common/layout/Layout.jsx
+++ b/sanjijikfarm/src/components/common/layout/Layout.jsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+
+import Header from './Header';
+
+export default function Layout() {
+  return (
+    <div className="h-screen w-full">
+      <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">
+        <Header />
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/sanjijikfarm/src/components/common/layout/Layout.jsx
+++ b/sanjijikfarm/src/components/common/layout/Layout.jsx
@@ -6,7 +6,7 @@ import NavBar from './NavBar';
 export default function Layout() {
   return (
     <div className="h-screen w-full">
-      <div className="mx-auto h-full max-w-[var(--frame-width)] shadow">
+      <div className="relative mx-auto h-full max-w-[var(--frame-width)] shadow">
         <Header />
         <Outlet />
         <NavBar />

--- a/sanjijikfarm/src/components/common/layout/NavBar.jsx
+++ b/sanjijikfarm/src/components/common/layout/NavBar.jsx
@@ -1,6 +1,6 @@
 export default function NavBar() {
   return (
-    <div className="absolute bottom-0 flex h-16 w-full items-center justify-center bg-white shadow-2xl">
+    <div className="absolute bottom-0 flex h-16 w-full items-center justify-center gap-8.5 bg-white shadow-2xl">
       <span className="text-body-2-med font-medium">홈</span>
       <span className="text-body-2-med font-medium">영수증</span>
       <span className="text-body-2-med font-medium">로컬푸드</span>

--- a/sanjijikfarm/src/components/common/layout/NavBar.jsx
+++ b/sanjijikfarm/src/components/common/layout/NavBar.jsx
@@ -1,6 +1,6 @@
 export default function NavBar() {
   return (
-    <div className="flex h-16 w-full items-center justify-center bg-white shadow-md">
+    <div className="absolute bottom-0 flex h-16 w-full items-center justify-center bg-white shadow-2xl">
       <span className="text-body-2-med font-medium">홈</span>
       <span className="text-body-2-med font-medium">영수증</span>
       <span className="text-body-2-med font-medium">로컬푸드</span>

--- a/sanjijikfarm/src/components/common/layout/NavBar.jsx
+++ b/sanjijikfarm/src/components/common/layout/NavBar.jsx
@@ -1,11 +1,28 @@
+// src/components/common/layout/NavBar.jsx
+import { NavLink } from 'react-router-dom';
+
 export default function NavBar() {
+  const navItems = [
+    { path: '/home', label: '홈' },
+    { path: '/receipt', label: '영수증' },
+    { path: '/localfood', label: '로컬푸드' },
+    { path: '/report', label: '소비리포트' },
+    { path: '/mypage', label: '마이페이지' },
+  ];
+
   return (
     <div className="absolute bottom-0 flex h-16 w-full items-center justify-center gap-8.5 bg-white shadow-2xl">
-      <span className="text-body-2-med font-medium">홈</span>
-      <span className="text-body-2-med font-medium">영수증</span>
-      <span className="text-body-2-med font-medium">로컬푸드</span>
-      <span className="text-body-2-med font-medium">소비리포트</span>
-      <span className="text-body-2-med font-medium">마이페이지</span>
+      {navItems.map((item) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          className={({ isActive }) =>
+            `text-body-2-med font-medium ${isActive ? 'text-green font-bold' : 'text-black'}`
+          }
+        >
+          {item.label}
+        </NavLink>
+      ))}
     </div>
   );
 }

--- a/sanjijikfarm/src/components/common/layout/NavBar.jsx
+++ b/sanjijikfarm/src/components/common/layout/NavBar.jsx
@@ -1,0 +1,11 @@
+export default function NavBar() {
+  return (
+    <div className="flex h-16 w-full items-center justify-center bg-white shadow-md">
+      <span className="text-body-2-med font-medium">홈</span>
+      <span className="text-body-2-med font-medium">영수증</span>
+      <span className="text-body-2-med font-medium">로컬푸드</span>
+      <span className="text-body-2-med font-medium">소비리포트</span>
+      <span className="text-body-2-med font-medium">마이페이지</span>
+    </div>
+  );
+}

--- a/sanjijikfarm/src/components/common/layout/ProtectedLayout.jsx
+++ b/sanjijikfarm/src/components/common/layout/ProtectedLayout.jsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+
+import Header from './Header';
+import NavBar from './NavBar';
+
+export default function ProtectedLayout() {
+  return (
+    <div className="h-screen w-full">
+      <div className="relative mx-auto h-full max-w-[var(--frame-width)] shadow">
+        <Header />
+        <Outlet />
+        <NavBar />
+      </div>
+    </div>
+  );
+}

--- a/sanjijikfarm/src/components/common/layout/ProtectedLayout.jsx
+++ b/sanjijikfarm/src/components/common/layout/ProtectedLayout.jsx
@@ -8,7 +8,9 @@ export default function ProtectedLayout() {
     <div className="h-screen w-full">
       <div className="relative mx-auto h-full max-w-[var(--frame-width)] shadow">
         <Header />
-        <Outlet />
+        <main className="h-full w-full pt-16 pb-16">
+          <Outlet />
+        </main>
         <NavBar />
       </div>
     </div>

--- a/sanjijikfarm/src/components/common/layout/PublicLayout.jsx
+++ b/sanjijikfarm/src/components/common/layout/PublicLayout.jsx
@@ -1,15 +1,10 @@
 import { Outlet } from 'react-router-dom';
 
-import Header from './Header';
-import NavBar from './NavBar';
-
-export default function Layout() {
+export default function PublicLayout() {
   return (
     <div className="h-screen w-full">
       <div className="relative mx-auto h-full max-w-[var(--frame-width)] shadow">
-        <Header />
         <Outlet />
-        <NavBar />
       </div>
     </div>
   );

--- a/sanjijikfarm/src/components/common/router/ProtectedRoute.jsx
+++ b/sanjijikfarm/src/components/common/router/ProtectedRoute.jsx
@@ -1,0 +1,14 @@
+// src/components/ProtectedRoute.tsx
+import { Navigate, Outlet } from 'react-router-dom';
+
+export default function ProtectedRoute() {
+  const { user } = true; // 이후 실제 인증 상태로 교체
+
+  if (!user) {
+    // 로그인 안 됐으면 로그인 페이지로 이동
+    return <Navigate to="/login" replace />;
+  }
+
+  // 로그인 되어있으면 자식 라우트 렌더링
+  return <Outlet />;
+}

--- a/sanjijikfarm/src/components/common/router/ProtectedRoute.jsx
+++ b/sanjijikfarm/src/components/common/router/ProtectedRoute.jsx
@@ -2,7 +2,7 @@
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function ProtectedRoute() {
-  const { user } = true; // 이후 실제 인증 상태로 교체
+  const user = true; // 이후 실제 인증 상태로 교체
 
   if (!user) {
     // 로그인 안 됐으면 로그인 페이지로 이동

--- a/sanjijikfarm/src/pages/HomePage.jsx
+++ b/sanjijikfarm/src/pages/HomePage.jsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>home</div>;
+}

--- a/sanjijikfarm/src/pages/LocalfoodPage.jsx
+++ b/sanjijikfarm/src/pages/LocalfoodPage.jsx
@@ -1,0 +1,3 @@
+export default function LocalfoodPage() {
+  return <div>localfood</div>;
+}

--- a/sanjijikfarm/src/pages/LoginPage.jsx
+++ b/sanjijikfarm/src/pages/LoginPage.jsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+  return <div>login</div>;
+}

--- a/sanjijikfarm/src/pages/MyPage.jsx
+++ b/sanjijikfarm/src/pages/MyPage.jsx
@@ -1,0 +1,3 @@
+export default function MyPage() {
+  return <div>mypage</div>;
+}

--- a/sanjijikfarm/src/pages/ReceiptPage.jsx
+++ b/sanjijikfarm/src/pages/ReceiptPage.jsx
@@ -1,0 +1,3 @@
+export default function ReceiptPage() {
+  return <div>receipt</div>;
+}

--- a/sanjijikfarm/src/pages/ReportPage.jsx
+++ b/sanjijikfarm/src/pages/ReportPage.jsx
@@ -1,0 +1,3 @@
+export default function ReportPage() {
+  return <div>report</div>;
+}

--- a/sanjijikfarm/src/pages/SplashPage.jsx
+++ b/sanjijikfarm/src/pages/SplashPage.jsx
@@ -1,0 +1,3 @@
+export default function SplashPage() {
+  return <div>splash</div>;
+}

--- a/sanjijikfarm/src/router.jsx
+++ b/sanjijikfarm/src/router.jsx
@@ -2,19 +2,32 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import ProtectedRoute from './components/common/router/ProtectedRoute';
+import HomePage from './pages/HomePage';
+import LocalfoodPage from './pages/LocalfoodPage';
+import LoginPage from './pages/LoginPage';
+import MyPage from './pages/MyPage';
+import ReceiptPage from './pages/ReceiptPage';
+import ReportPage from './pages/ReportPage';
+import SplashPage from './pages/SplashPage';
 
 export const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
     children: [
-      { index: true },
-      { path: 'login' },
+      { index: true, element: <SplashPage /> },
+      { path: 'login', element: <LoginPage /> },
 
       // protected routes
       {
         element: <ProtectedRoute />,
-        children: [],
+        children: [
+          { path: 'home', element: <HomePage /> },
+          { path: 'localfood', element: <LocalfoodPage /> },
+          { path: 'receipt', element: <ReceiptPage /> },
+          { path: 'report', element: <ReportPage /> },
+          { path: 'mypage', element: <MyPage /> },
+        ],
       },
     ],
   },

--- a/sanjijikfarm/src/router.jsx
+++ b/sanjijikfarm/src/router.jsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 
+import ProtectedLayout from './components/common/layout/ProtectedLayout';
 import PublicLayout from './components/common/layout/PublicLayout';
 import ProtectedRoute from './components/common/router/ProtectedRoute';
 import HomePage from './pages/HomePage';
@@ -22,11 +23,16 @@ export const router = createBrowserRouter([
       {
         element: <ProtectedRoute />,
         children: [
-          { path: 'home', element: <HomePage /> },
-          { path: 'localfood', element: <LocalfoodPage /> },
-          { path: 'receipt', element: <ReceiptPage /> },
-          { path: 'report', element: <ReportPage /> },
-          { path: 'mypage', element: <MyPage /> },
+          {
+            element: <ProtectedLayout />,
+            children: [
+              { path: 'home', element: <HomePage /> },
+              { path: 'localfood', element: <LocalfoodPage /> },
+              { path: 'receipt', element: <ReceiptPage /> },
+              { path: 'report', element: <ReportPage /> },
+              { path: 'mypage', element: <MyPage /> },
+            ],
+          },
         ],
       },
     ],

--- a/sanjijikfarm/src/router.jsx
+++ b/sanjijikfarm/src/router.jsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 
-import App from './App';
+import PublicLayout from './components/common/layout/PublicLayout';
 import ProtectedRoute from './components/common/router/ProtectedRoute';
 import HomePage from './pages/HomePage';
 import LocalfoodPage from './pages/LocalfoodPage';
@@ -13,7 +13,7 @@ import SplashPage from './pages/SplashPage';
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <App />,
+    element: <PublicLayout />,
     children: [
       { index: true, element: <SplashPage /> },
       { path: 'login', element: <LoginPage /> },

--- a/sanjijikfarm/src/router.jsx
+++ b/sanjijikfarm/src/router.jsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter } from 'react-router-dom';
+
+import App from './App';
+import ProtectedRoute from './components/common/router/ProtectedRoute';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true },
+      { path: 'login' },
+
+      // protected routes
+      {
+        element: <ProtectedRoute />,
+        children: [],
+      },
+    ],
+  },
+]);

--- a/sanjijikfarm/yarn.lock
+++ b/sanjijikfarm/yarn.lock
@@ -2379,6 +2379,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
 core-js-compat@^3.43.0:
   version "3.45.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.45.1.tgz#424f3f4af30bf676fd1b67a579465104f64e9c7a"
@@ -4129,6 +4134,21 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
+react-router-dom@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.8.2.tgz#25a8fc36588189baf3bbb5e360c8ffffbd2beabc"
+  integrity sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==
+  dependencies:
+    react-router "7.8.2"
+
+react-router@7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.8.2.tgz#9d2d4147ca72832c550acc60ed688062d18f70b8"
+  integrity sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==
+  dependencies:
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+
 react@^19.1.1:
   version "19.1.1"
   resolved "https://registry.yarnpkg.com/react/-/react-19.1.1.tgz#06d9149ec5e083a67f9a1e39ce97b06a03b644af"
@@ -4303,6 +4323,11 @@ semver@^7.3.7, semver@^7.6.0:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 set-function-length@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## ✅ 작업 내용
- Header, NavBar 구현
- Router 기본 구조 구현
- Pages 기본 구조 추가

---

## 📌 관련 이슈
- 관련 이슈: Closes #1 

---

## 💬 특이사항
- protected page 관련 하드코딩으로 작성 (로그인 백엔드 연결 전)
- 직접 path를 /home으로 수정하면 홈 페이지 나오고, navbar로 각 페이지 접근 가능

---

## 🖼️ 스크린샷 (선택)
<img width="416" height="908" alt="스크린샷 2025-09-05 오후 3 18 09" src="https://github.com/user-attachments/assets/cf20c170-b1ad-40ab-8cda-b7664c0dab80" />
