### PR TITLE
[Feat/#41 receipt upload api] 영수증 업로드 - 서버리스 OCR 연결 

### DIFF
--- a/sanjijikfarm/src/api/axios/auth.js
+++ b/sanjijikfarm/src/api/axios/auth.js
@@ -18,6 +18,10 @@ export const login = (username, password) =>
 
     if (data.success && data.token && data.refreshToken) {
       useAuthStore.getState().setTokens(data.token, data.refreshToken);
+      useAuthStore.getState().setUsername(username);
+    }
+    if (data.username) {
+      useAuthStore.getState().setUsername(data.username);
     }
     return data;
   });

--- a/sanjijikfarm/src/api/axios/store.js
+++ b/sanjijikfarm/src/api/axios/store.js
@@ -3,7 +3,9 @@ import { create } from 'zustand';
 export const useAuthStore = create((set) => ({
   accessToken: null,
   refreshToken: null,
+  username: null,
 
   setTokens: (access, refresh) => set({ accessToken: access, refreshToken: refresh }),
+  setUsername: (name) => set({ username: name }),
   clear: () => set({ accessToken: null, refreshToken: null }),
 }));

--- a/sanjijikfarm/src/api/receipt/receipt.js
+++ b/sanjijikfarm/src/api/receipt/receipt.js
@@ -1,0 +1,12 @@
+import { axiosInstance, withErrorBoundary } from '../axios/axios';
+
+// 서버리스 OCR API 연동
+export const uploadReceiptToOCR = (imageBase64, username) =>
+  withErrorBoundary(async () => {
+    const res = await axiosInstance.post(
+      'https://tqs0vow7qk.apigw.ntruss.com/custom/v1/ocr',
+      { imageBase64, username },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+    return res.data;
+  });

--- a/sanjijikfarm/src/pages/ReceiptUploadPage.jsx
+++ b/sanjijikfarm/src/pages/ReceiptUploadPage.jsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { uploadReceiptToOCR } from '@/api/receipt/receipt';
 import { useAuthStore } from '@/api/axios/store';
-const { username } = useAuthStore.getState();
-console.log(username);
 
 export default function ReceiptUploadPage() {
   const [image, setImage] = useState(null);

--- a/sanjijikfarm/src/pages/ReceiptUploadPage.jsx
+++ b/sanjijikfarm/src/pages/ReceiptUploadPage.jsx
@@ -1,4 +1,8 @@
 import { useState } from 'react';
+import { uploadReceiptToOCR } from '@/api/receipt/receipt';
+import { useAuthStore } from '@/api/axios/store';
+const { username } = useAuthStore.getState();
+console.log(username);
 
 export default function ReceiptUploadPage() {
   const [image, setImage] = useState(null);
@@ -14,21 +18,32 @@ export default function ReceiptUploadPage() {
     reader.readAsDataURL(file);
   };
 
-  const handleUpload = () => {
+  const handleUpload = async () => {
     if (!image) {
       alert('이미지를 먼저 선택해주세요!');
       return;
     }
 
-    // TODO: 업로드 API 연동
-    console.log('업로드 시작:', image);
+    try {
+      const base64Image = image.split(',')[1];
+      const { username } = useAuthStore.getState();
+
+      const data = await uploadReceiptToOCR(base64Image, username);
+
+      console.log('OCR 결과:', data);
+      alert('업로드가 완료되었습니다!');
+    } catch (err) {
+      console.error('OCR 업로드 실패:', err);
+      alert(err.message || 'OCR 요청 중 오류가 발생했습니다.');
+    }
   };
+
 
   return (
     <div className="mx-auto w-full max-w-md px-4 py-8">
       <h1 className="text-title-3 mb-5 text-center font-bold">영수증 업로드</h1>
 
-      {/* 이미지 업로드 박스 (작게!) */}
+      {/* 이미지 업로드 박스 */}
       <div className="relative mx-auto mb-6 flex h-[400px] w-[230px] items-center justify-center overflow-hidden rounded-md border-2 border-dashed bg-gray-100">
         {image ? (
           <>


### PR DESCRIPTION
## ✅ 작업 내용
- 영수증 업로드 - Clova OCR 연동  
---

## 📌 관련 이슈
- 관련 이슈: #41 

---

## 💬 특이사항
- 영수증 결과 화면은 백엔드 API 개발 후 연동 예정 (현재는 영수증 업로드 후 업로드 완료 알림, console log에만 OCR 결과 반환됨) 
- 계정별 구분하여 저장하기 위해 auth.js, store.js에 username 로직 추가 
---

## 🖼️ 스크린샷 (선택)
<img width="486" height="250" alt="스크린샷 2025-09-30 오후 5 31 54" src="https://github.com/user-attachments/assets/2739a607-9bd4-4a04-9c11-703077095b61" />


