### PR TITLE
fix: 소비리포트 월별 이동 수정 

### DIFF
--- a/sanjijikfarm/src/pages/ReportPage.jsx
+++ b/sanjijikfarm/src/pages/ReportPage.jsx
@@ -14,14 +14,20 @@ export default function ReportPage() {
   const month = targetDate.month() + 1 + '';
   const year = targetDate.year() + '';
 
+  const now = dayjs();
+  const lastMonth = now.subtract(1, 'month');
+
+  const isAtLastMonth = targetDate.isSame(lastMonth, 'month');
+  const isAtCurrentMonth = targetDate.isSame(now, 'month');
+
   const handlePrevMonth = () => {
-    setTargetDate((prev) => prev.subtract(1, 'month'));
+    if (isAtLastMonth) return;
+    setTargetDate(targetDate.subtract(1, 'month'));
   };
 
   const handleNextMonth = () => {
-    const next = targetDate.add(1, 'month');
-    if (next.isAfter(dayjs(), 'month')) return;
-    setTargetDate(next);
+    if (isAtCurrentMonth) return;
+    setTargetDate(targetDate.add(1, 'month'));
   };
 
   const {
@@ -91,11 +97,23 @@ export default function ReportPage() {
   return (
     <div className="scrollbar-hide h-screen max-h-[82vh] overflow-y-auto pt-[1.7rem]">
       <div className="mb-2 flex items-center justify-center gap-4">
-        <button onClick={handlePrevMonth} className="px-2 text-xl">
+        <button
+          onClick={handlePrevMonth}
+          disabled={isAtLastMonth}
+          className={`px-2 text-xl transition ${isAtLastMonth ? 'cursor-not-allowed opacity-50' : 'hover:opacity-80'}`}
+        >
           {'<'}
         </button>
+
         <h2 className="text-title-3 font-bold">{`${year}년 ${month}월`}</h2>
-        <button onClick={handleNextMonth} className="px-2 text-xl">
+
+        <button
+          onClick={handleNextMonth}
+          disabled={isAtCurrentMonth}
+          className={`px-2 text-xl transition ${
+            isAtCurrentMonth ? 'cursor-not-allowed opacity-50' : 'hover:opacity-80'
+          }`}
+        >
           {'>'}
         </button>
       </div>


### PR DESCRIPTION
## ✅ 작업 내용
- 월별 이동 지난달, 이번달만 가능하도록 수정 
---

## 📌 관련 이슈
---

## 💬 특이사항
- 이동 불가능할 시 <> 버튼 연한 색으로 수정 

---

## 🖼️ 스크린샷 (선택)
<img width="402" height="437" alt="스크린샷 2025-10-17 오후 4 37 53" src="https://github.com/user-attachments/assets/a2d2f306-2a72-40e4-aef1-2a84cf855578" />
<img width="402" height="437" alt="스크린샷 2025-10-17 오후 4 37 56" src="https://github.com/user-attachments/assets/5b64c3f5-3406-45ad-a755-e280a173bf28" />

